### PR TITLE
Socket path change, GCC13 support, clangd lint support

### DIFF
--- a/OpenVR-SpaceCalibrator/IPCClient.cpp
+++ b/OpenVR-SpaceCalibrator/IPCClient.cpp
@@ -20,7 +20,7 @@ void IPCClient::Connect()
 	if (fd == -1) {
 		throw std::runtime_error("Could not create socket");
 	}
-	std::string socketPath = std::string(getenv("HOME")) + "/.local/share/OpenVR-SpaceCalibrator/socket";
+	std::string socketPath = std::string(getenv("XDG_RUNTIME_DIR")) + "/openvr-spacecal";
 	struct sockaddr_un address;
 	memset(&address, 0, sizeof(struct sockaddr_un));
 	address.sun_family = AF_UNIX;

--- a/OpenVR-SpaceCalibrator/IPCClient.cpp
+++ b/OpenVR-SpaceCalibrator/IPCClient.cpp
@@ -20,7 +20,7 @@ void IPCClient::Connect()
 	if (fd == -1) {
 		throw std::runtime_error("Could not create socket");
 	}
-	std::string socketPath = std::string(getenv("XDG_RUNTIME_DIR")) + "/openvr-spacecal";
+	std::string socketPath = std::string(getenv("XDG_RUNTIME_DIR")) + "/openvr-spacecal.sock";
 	struct sockaddr_un address;
 	memset(&address, 0, sizeof(struct sockaddr_un));
 	address.sun_family = AF_UNIX;

--- a/OpenVR-SpaceCalibratorDriver/Hooking.h
+++ b/OpenVR-SpaceCalibratorDriver/Hooking.h
@@ -7,6 +7,7 @@
 #include <stdexcept>
 #include <vector>
 #include <unistd.h>
+#include <cstdint>
 
 class IHook
 {

--- a/OpenVR-SpaceCalibratorDriver/IPCServer.cpp
+++ b/OpenVR-SpaceCalibratorDriver/IPCServer.cpp
@@ -69,7 +69,7 @@ void IPCServer::RunThread(IPCServer *_this)
 		LOG("socket failed in RunThread. Error: %s", strerror(errno));
 		return;
 	}
-	std::string socketPath = std::string(getenv("HOME")) + "/.local/share/OpenVR-SpaceCalibrator/socket";
+	std::string socketPath = std::string(getenv("XDG_RUNTIME_DIR")) + "/openvr-spacecal";
 	unlink(socketPath.c_str());
 	struct sockaddr_un serverAddress;
 	memset(&serverAddress, 0, sizeof(struct sockaddr_un));

--- a/OpenVR-SpaceCalibratorDriver/IPCServer.cpp
+++ b/OpenVR-SpaceCalibratorDriver/IPCServer.cpp
@@ -69,7 +69,7 @@ void IPCServer::RunThread(IPCServer *_this)
 		LOG("socket failed in RunThread. Error: %s", strerror(errno));
 		return;
 	}
-	std::string socketPath = std::string(getenv("XDG_RUNTIME_DIR")) + "/openvr-spacecal";
+	std::string socketPath = std::string(getenv("XDG_RUNTIME_DIR")) + "/openvr-spacecal.sock";
 	unlink(socketPath.c_str());
 	struct sockaddr_un serverAddress;
 	memset(&serverAddress, 0, sizeof(struct sockaddr_un));

--- a/install.sh
+++ b/install.sh
@@ -20,7 +20,7 @@ fi
 
 echo "SteamVR found at $STEAMVR_DIR"
 
-cmake $SRC_DIR
+cmake -DCMAKE_EXPORT_COMPILE_COMMANDS=1 $SRC_DIR
 cp $SRC_DIR/lib/openvr/lib/linux64/libopenvr_api.so .
 
 make -j $(nproc)


### PR DESCRIPTION
So i was debugging why it didn't work on my distrobox installation and it turns out that by default socket paths are rather limited on Linux, and most other systems. In my case, my path was over 108 chars long, and it caused stack smashing in both companion and driver. So i decided to change the path to `XDG_RUNTIME_DIR` as it's probably the best place for it anyway.
While doing this, gcc13 update has come to arch and it broke compilation, thankfully it was a simple one line fix which gcc told by itself (`cstdint`).
And just for future i added export compile commands so that you will have proper linting support on clangd after building.